### PR TITLE
:gift_heart: Allow error handlers to access the Cobra' command object

### DIFF
--- a/app.go
+++ b/app.go
@@ -20,8 +20,9 @@ type App struct {
 }
 
 // ErrorHandler is a function that will be used to handle the errors. If true
-// is returned, the default error handling will not be used.
-type ErrorHandler func(err error) bool
+// is returned, the default error handling will not be used. The Cobra's command
+// passed to the error handler is the command that thrown the error.
+type ErrorHandler func(err error, cmd *cobra.Command) bool
 
 // CobraProvider is used to provide a Cobra command.
 type CobraProvider interface {
@@ -42,7 +43,7 @@ func (a *App) ExecuteOrDie(options ...Option) {
 	if err == nil {
 		return
 	}
-	if a.ErrorHandler == nil || !a.ErrorHandler(err) {
+	if a.ErrorHandler == nil || !a.ErrorHandler(err, a.root) {
 		a.defaultErrorHandler(err)
 	}
 }

--- a/app_test.go
+++ b/app_test.go
@@ -24,7 +24,7 @@ func TestExecuteOrDie(t *testing.T) {
 		commandline.WithExit(func(code int) {
 			retcode = code
 		}),
-		commandline.WithErrorHandler(func(merr error) bool {
+		commandline.WithErrorHandler(func(merr error, _ *cobra.Command) bool {
 			err = merr
 			return false
 		}),


### PR DESCRIPTION
Allow error handlers to access the Cobra' command object

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling capabilities by providing context about the command that triggered an error.

- **Bug Fixes**
	- Updated error handler to improve processing and context management during error occurrences.

- **Tests**
	- Adjusted test functions to align with the updated error handler signature, ensuring consistent testing practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->